### PR TITLE
Added aws-iam-authenticator to Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,5 +7,8 @@ RUN pip install awscli
 RUN curl -L -o /usr/bin/kubectl https://amazon-eks.s3-us-west-2.amazonaws.com/1.14.6/2019-08-22/bin/linux/amd64/kubectl
 RUN chmod +x /usr/bin/kubectl
 
+RUN curl -L -o /usr/bin/aws-iam-authenticator https://amazon-eks.s3-us-west-2.amazonaws.com/1.14.6/2019-08-22/bin/linux/amd64/aws-iam-authenticator
+RUN chmod +x /usr/bin/aws-iam-authenticator
+
 COPY entrypoint.sh /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]


### PR DESCRIPTION
This allows tools that use kubectl and specify aws-iam-authentictor in their `~/.kube/config` file to work