### PR TITLE
Added aws-iam-authenticator

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,9 @@ RUN apk add py-pip curl
 RUN pip install awscli
 RUN curl -L -o /usr/bin/kubectl https://amazon-eks.s3.us-west-2.amazonaws.com/1.15.10/2020-02-22/bin/linux/amd64/kubectl
 RUN chmod +x /usr/bin/kubectl
+RUN curl -o /usr/local/bin/aws-iam-authenticator https://amazon-eks.s3.us-west-2.amazonaws.com/1.17.7/2020-07-08/bin/linux/amd64/aws-iam-authenticator
+RUN chmod +x /usr/local/bin/aws-iam-authenticator
+
 
 COPY entrypoint.sh /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]


### PR DESCRIPTION
This fixes the following issue:
`exec: "aws-iam-authenticator": executable file not found in $PATH` 

original issue can be found here:
https://github.com/ConsenSys/kubernetes-action/issues/5
